### PR TITLE
Fix typo in zext helper assertion

### DIFF
--- a/tpde/include/tpde/util/misc.hpp
+++ b/tpde/include/tpde/util/misc.hpp
@@ -74,7 +74,7 @@ constexpr u64 cnt_lz<u64>(const u64 val) {
 }
 
 inline u64 zext(const u64 val, const unsigned bits) {
-  assert(bits > 0 && bits < 64 && "invalid sext bit width");
+  assert(bits > 0 && bits < 64 && "invalid zext bit width");
   return val & ((u64{1} << bits) - 1);
 }
 


### PR DESCRIPTION
Fix typo in zext helper assertion, probably copy/paste artifact