### PR TITLE
[TPDE][LLVM] Add support for debug line info

### DIFF
--- a/tpde-llvm/src/LLVMCompilerBase.hpp
+++ b/tpde-llvm/src/LLVMCompilerBase.hpp
@@ -25,6 +25,7 @@
 
 #include "tpde/Assembler.hpp"
 #include "tpde/CompilerBase.hpp"
+#include "tpde/DwarfLineWriter.hpp"
 #include "tpde/ValLocalIdx.hpp"
 #include "tpde/ValueAssignment.hpp"
 #include "tpde/base.hpp"
@@ -168,6 +169,8 @@ struct LLVMCompilerBase : public LLVMCompiler,
   llvm::DenseMap<const llvm::Comdat *, SecRef> group_secs;
 
   tpde::util::SmallVector<std::pair<IRValueRef, SymRef>, 16> type_info_syms;
+
+  std::unique_ptr<tpde::DwarfLineWriter> dw_line_writer;
 
   enum class LibFunc {
     divti3,
@@ -335,6 +338,66 @@ private:
   }
 
 public:
+  /// Record a debug location at the current PC
+  void record_debug_location(llvm::DebugLoc debug_loc) {
+    if (!dw_line_writer || !debug_loc) {
+      return;
+    }
+
+    const u32 current_pc = this->text_writer.offset();
+    // Avoid emitting duplicate locations for the same PC, which can happen
+    // when multiple instructions share the same debug location.
+    if (dw_line_writer->offset_equals_last_offset(current_pc)) {
+      return;
+    }
+
+    const llvm::DILocation *di_loc = debug_loc.get();
+    const u32 line = di_loc->getLine();
+    // Line number 0 is used to indicate an unknown location, so skip it.
+    if (line == 0) {
+      return;
+    }
+
+    dw_line_writer->push_location(
+        current_pc,
+        tpde::DebugLocation{
+            .file_name = di_loc->getFilename(),
+            .directory = di_loc->getDirectory(),
+            .line = di_loc->getLine(),
+            .column = static_cast<u16>(di_loc->getColumn()),
+        });
+  }
+
+  void set_current_debug_location_function(const IRFuncRef func) {
+    if (!dw_line_writer) {
+      return;
+    }
+
+    const u32 current_pc = this->text_writer.offset();
+    if (const llvm::DISubprogram *sp = func->getSubprogram()) {
+      dw_line_writer->push_location(
+        current_pc,
+        tpde::DebugLocation{
+            .file_name = sp->getFilename(),
+            .directory = sp->getDirectory(),
+            .line = sp->getLine(),
+            .column = 0u,
+        });
+      dw_line_writer->set_subprogram_written();
+    }
+  }
+
+  void finish_debug_location_function(const IRFuncRef, const u32 func_idx) {
+    if (!dw_line_writer) {
+      return;
+    }
+
+    const u32 sym_id = this->func_syms[func_idx].id();
+    const auto it = this->func_sym_id_to_skew.find(sym_id);
+    const u32 skew = (it != this->func_sym_id_to_skew.end()) ? it->second : 0u;
+    dw_line_writer->end_function(skew);
+  }
+
   /// Whether to use a DSO-local access instead of going through the GOT.
   static bool use_local_access(const llvm::GlobalValue *gv) {
     // If the symbol is preemptible, don't generate a local access.
@@ -1250,6 +1313,11 @@ bool LLVMCompilerBase<Adaptor, Derived, Config>::compile(llvm::Module &mod) {
   group_secs.clear();
   libfunc_syms.fill({});
 
+  if (mod.getNamedMetadata("llvm.dbg.cu") != nullptr) {
+    const tpde::DwarfConfig cfg(Config::MIN_INST_WIDTH);
+    dw_line_writer = std::make_unique<tpde::DwarfLineWriter>(cfg);
+  }
+
   if (!Base::compile()) {
     return false;
   }
@@ -1268,6 +1336,12 @@ bool LLVMCompilerBase<Adaptor, Derived, Config>::compile(llvm::Module &mod) {
     auto from_sym = global_sym(alias_target);
 
     this->assembler.sym_copy(dst_sym, from_sym);
+  }
+
+  // Write DWARF 5 line information if enabled and the module has debug info.
+  if (dw_line_writer) {
+    llvm::TimeTraceScope time_scope("TPDE_DebugLine_Write");
+    dw_line_writer->finalize(this->assembler);
   }
 
   return true;
@@ -1365,6 +1439,9 @@ bool LLVMCompilerBase<Adaptor, Derived, Config>::compile_inst(
     // clang-format on
     return res;
   }();
+
+  // Record debug location before instruction
+  record_debug_location(i->getDebugLoc());
 
   const ValInfo &val_info = this->adaptor->val_info(i);
   assert(i->getOpcode() < fns.size());

--- a/tpde/CMakeLists.txt
+++ b/tpde/CMakeLists.txt
@@ -33,6 +33,7 @@ target_sources(tpde PRIVATE
     src/Assembler.cpp
     src/AssemblerElf.cpp
     src/base.cpp
+    src/DwarfLineWriter.cpp
     src/ElfMapper.cpp
     src/FunctionWriter.cpp
     src/StringTable.cpp
@@ -52,6 +53,7 @@ target_sources(tpde PRIVATE
         include/tpde/CompilerBase.hpp
         include/tpde/CompilerConfig.hpp
         include/tpde/DWARF.hpp
+        include/tpde/DwarfLineWriter.hpp
         include/tpde/ELF.hpp
         include/tpde/ElfMapper.hpp
         include/tpde/FunctionWriter.hpp

--- a/tpde/include/tpde/Assembler.hpp
+++ b/tpde/include/tpde/Assembler.hpp
@@ -53,15 +53,18 @@ struct Relocation {
 
 /// Section kinds, lowered to file-format specific flags.
 enum class SectionKind : u8 {
-  Text,       ///< Text section, executable code (ELF .text)
-  ReadOnly,   ///< Read-only data section (ELF .rodata)
-  EHFrame,    ///< EH Frame section (ELF .eh_frame)
-  LSDA,       ///< LSDA section (ELF .gcc_except_table)
-  Data,       ///< Writable data section (ELF .data)
-  DataRelRO,  ///< Read-only data section with relocations (ELF .data.rel.ro)
-  BSS,        ///< Zero-initialized data section (ELF .bss)
-  ThreadData, ///< Initialized thread-local data section (ELF .tdata)
-  ThreadBSS,  ///< Zero-initialized thread-local data section (ELF .tbss)
+  Text,        ///< Text section, executable code (ELF .text)
+  ReadOnly,    ///< Read-only data section (ELF .rodata)
+  EHFrame,     ///< EH Frame section (ELF .eh_frame)
+  LSDA,        ///< LSDA section (ELF .gcc_except_table)
+  Data,        ///< Writable data section (ELF .data)
+  DataRelRO,   ///< Read-only data section with relocations (ELF .data.rel.ro)
+  BSS,         ///< Zero-initialized data section (ELF .bss)
+  ThreadData,  ///< Initialized thread-local data section (ELF .tdata)
+  ThreadBSS,   ///< Zero-initialized thread-local data section (ELF .tbss)
+  DebugInfo,   ///< DWARF debug info (ELF .debug_info)
+  DebugLine,   ///< DWARF line information (ELF .debug_line)
+  DebugAbbrev, ///< DWARF abbreviations (ELF .debug_abbrev)
 
   Max
 };

--- a/tpde/include/tpde/CompilerBase.hpp
+++ b/tpde/include/tpde/CompilerBase.hpp
@@ -194,6 +194,8 @@ public:
   // allocations
   util::SmallVector<Label> block_labels;
 
+  std::unordered_map<u32, u32> func_sym_id_to_skew; // Map SymRef.id() to address skew
+
   util::SmallVector<std::pair<SymRef, SymRef>, 4> personality_syms = {};
 
   struct ScratchReg;
@@ -577,6 +579,10 @@ public:
   void analysis_start() {}
 
   void analysis_end() {}
+
+  void set_current_debug_location_function(const IRFuncRef) {}
+
+  void finish_debug_location_function(const IRFuncRef, const u32) {}
 
   void reloc_text(SymRef sym, u32 type, u64 offset, i64 addend = 0) {
     this->assembler.reloc_sec(
@@ -2315,6 +2321,8 @@ bool CompilerBase<Adaptor, Derived, Config>::compile_func(const IRFuncRef func,
 
   derived()->start_func(func_idx);
 
+  derived()->set_current_debug_location_function(func);
+
   block_labels.clear();
   block_labels.resize_uninitialized(analyzer.block_layout.size());
   for (u32 i = 0; i < analyzer.block_layout.size(); ++i) {
@@ -2403,6 +2411,7 @@ bool CompilerBase<Adaptor, Derived, Config>::compile_func(const IRFuncRef func,
          "found non-freed ValueAssignment, maybe missing ref-count?");
 
   derived()->finish_func(func_idx);
+  derived()->finish_debug_location_function(func, func_idx);
   this->text_writer.finish_func();
 
   return true;

--- a/tpde/include/tpde/CompilerConfig.hpp
+++ b/tpde/include/tpde/CompilerConfig.hpp
@@ -22,6 +22,7 @@ concept CompilerConfig = requires {
   { T::PLATFORM_POINTER_SIZE } -> SameBaseAs<u32>;
   { T::NUM_BANKS } -> SameBaseAs<u32>;
   { T::DEFAULT_VAR_REF_HANDLING } -> SameBaseAs<bool>;
+  { T::MIN_INST_WIDTH } -> SameBaseAs<u8>;
 
   typename T::DefaultCCAssigner;
   requires std::derived_from<typename T::DefaultCCAssigner, CCAssigner>;
@@ -33,6 +34,7 @@ concept CompilerConfig = requires {
 
 struct CompilerConfigDefault {
   constexpr static bool DEFAULT_VAR_REF_HANDLING = true;
+  constexpr static u8 MIN_INST_WIDTH = 1;
 };
 
 } // namespace tpde

--- a/tpde/include/tpde/DWARF.hpp
+++ b/tpde/include/tpde/DWARF.hpp
@@ -34,6 +34,45 @@ constexpr u8 DWARF_CFI_PRIMARY_OPCODE_MASK = 0xc0;
 
 constexpr u32 EH_FDE_FUNC_START_OFF = 0x8;
 
+constexpr u8 DW_LNS_extended_op = 0;
+constexpr u8 DW_LNS_copy = 1;
+constexpr u8 DW_LNS_advance_pc = 2;
+constexpr u8 DW_LNS_advance_line = 3;
+constexpr u8 DW_LNS_set_file = 4;
+constexpr u8 DW_LNS_set_column = 5;
+constexpr u8 DW_LNS_negate_stmt = 6;
+constexpr u8 DW_LNS_set_basic_block = 7;
+constexpr u8 DW_LNS_const_add_pc = 8;
+constexpr u8 DW_LNS_fixed_advance_pc = 9;
+constexpr u8 DW_LNS_set_prologue_end = 10;
+constexpr u8 DW_LNS_set_epilogue_begin = 11;
+constexpr u8 DW_LNS_set_isa = 12;
+
+constexpr u8 DW_LNE_end_sequence = 1;
+constexpr u8 DW_LNE_set_address = 2;
+constexpr u8 DW_LNE_define_file = 3;
+constexpr u8 DW_LNE_set_discriminator = 4;
+
+constexpr u8 DW_TAG_compile_unit = 17;
+
+constexpr u8 DW_AT_stmt_list = 16;
+constexpr u8 DW_AT_low_pc = 17;
+constexpr u8 DW_AT_high_pc = 18;
+
+constexpr u8 DW_FORM_addr = 1;
+constexpr u8 DW_FORM_string = 8;
+constexpr u8 DW_FORM_udata = 0x0f;
+constexpr u8 DW_FORM_sec_offset = 23;
+
+// DWARF 5 line content type codes
+constexpr u8 DW_LNCT_path = 1;
+constexpr u8 DW_LNCT_directory_index = 2;
+
+// DWARF 5 unit type codes
+constexpr u8 DW_UT_compile = 0x01;
+
+constexpr u8 DW_CHILDREN_no = 0;
+
 namespace x64 {
 constexpr u8 DW_reg_rax = 0;
 constexpr u8 DW_reg_rdx = 1;

--- a/tpde/include/tpde/DwarfLineWriter.hpp
+++ b/tpde/include/tpde/DwarfLineWriter.hpp
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: 2025 Contributors to TPDE <https://tpde.org>
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#pragma once
+
+#include <map>
+#include <vector>
+
+#include "tpde/Assembler.hpp"
+#include "tpde/base.hpp"
+#include "tpde/util/SmallVector.hpp"
+#include "tpde/util/VectorWriter.hpp"
+
+namespace tpde {
+
+/// Source location extracted from IR/compiler metadata.
+struct DebugLocation {
+  std::string_view file_name;
+  std::string_view directory;
+  u32 line;
+  u16 column;
+};
+
+struct DebugFileEntry {
+  std::string_view name;
+  u32 dir_index;
+};
+
+/// DWARF line number program parameters (target-architecture-dependent).
+struct DwarfConfig {
+  u8 minimum_instruction_length;
+  u8 maximum_operations_per_instruction = 1;
+  bool default_is_stmt = true;
+  i8 line_base = -5;
+  u8 line_range = 14;
+  u8 opcode_base = 13;
+
+  explicit DwarfConfig(u8 min_inst_width)
+      : minimum_instruction_length(min_inst_width) {}
+};
+
+struct PendingEntry {
+  u32 raw_pc_offset;
+  DebugLocation loc;
+};
+
+/// On-the-fly DWARF 5 line info writer.
+///
+/// File and directory tables grow dynamically as functions are compiled.
+/// The line program is buffered incrementally. At finalization the header
+/// (with the now-complete file/directory tables) is prepended and all three
+/// DWARF sections are written to the assembler.
+class DwarfLineWriter {
+public:
+  explicit DwarfLineWriter(const DwarfConfig &cfg);
+
+  /// Called before each compiled instruction with the raw (pre-skew-correction)
+  /// text-section offset and the corresponding source location.
+  void push_location(u32 raw_pc_offset, DebugLocation loc);
+
+  // Check if the given raw_pc_offset is the same as the last emitted one. If
+  // so, it should be safe to skip emitting a new location.
+  bool offset_equals_last_offset(u32 raw_pc_offset);
+
+  /// Called after each function is fully compiled and the prologue skew is
+  /// known. Applies skew to all raw pc_offsets (except the initial entry at 0),
+  /// sorts and deduplicates records, and emits DWARF state-machine opcodes into
+  /// the line program buffer. All functions share a single sequence;
+  /// DW_LNE_end_sequence is emitted once by finalize().
+  void end_function(u32 skew);
+
+  /// Writes .debug_line, .debug_abbrev, and .debug_info sections to the
+  /// assembler. Must be called after all end_function() calls.
+  void finalize(Assembler &assembler);
+
+  /// Indicates that a subprogram has been written for the current function,
+  /// so the initial pending entry at offset 0 should be left unskewed.
+  void set_subprogram_written();
+
+private:
+  struct LineState {
+    u64 address = 0;
+    u32 file = UINT32_MAX; // sentinel: force set_file on first record
+    u32 line = 1;
+    u32 column = 0;
+    bool prologue_end = false;
+    bool epilogue_begin = false;
+  };
+
+  // Configuration
+  const tpde::DwarfConfig cfg;
+
+  // Per-function temporary state
+  std::vector<PendingEntry> pending;
+
+  // File and directory tables (filled dynamically during end_function calls)
+  using DirIdxMap = std::map<std::string_view, u32>;
+  std::vector<std::string_view> directories;
+  DirIdxMap dir_idx_map;
+  using FileIdxMap = std::map<std::pair<u32, std::string_view>, u32>;
+  std::vector<DebugFileEntry> files;
+  FileIdxMap file_idx_map; // (dir_idx, name) → index
+
+  // Buffered line program opcodes (all functions appended sequentially)
+  util::SmallVector<u8, 1024> prog_buf;
+
+  // DWARF state machine state (carries across functions within the single
+  // sequence)
+  LineState state;
+  bool sequence_started = false;
+  bool subprogram_written = false;
+
+  // PC range tracking for .debug_info DW_AT_low_pc / DW_AT_high_pc
+  u64 low_pc = UINT64_MAX;
+  u64 high_pc = 0;
+
+  u32 ensure_dir(const std::string_view &dir);
+  u32 ensure_file(const std::string_view &name, u32 dir_idx);
+
+  // DWARF line number program opcode emitters
+  void emit_set_address(util::VectorWriter &w, u64 addr);
+  void emit_end_sequence(util::VectorWriter &w);
+  void emit_advance_line(util::VectorWriter &w, i32 delta);
+  void emit_advance_pc(util::VectorWriter &w, u64 delta);
+  void emit_set_file(util::VectorWriter &w, u32 file_idx);
+  void emit_set_column(util::VectorWriter &w, u32 col);
+  void emit_set_prologue_end(util::VectorWriter &w);
+  void emit_set_epilogue_begin(util::VectorWriter &w);
+  void emit_copy(util::VectorWriter &w);
+
+  void emit_record(util::VectorWriter &w,
+                   u32 pc_offset,
+                   u32 file_idx,
+                   u32 line,
+                   u16 col,
+                   bool prologue_end,
+                   bool epilogue_begin);
+
+  // Section writing helpers
+  void write_directory_table(util::VectorWriter &w) const;
+  void write_file_table(util::VectorWriter &w) const;
+  void write_string(util::VectorWriter &w, const std::string_view &s) const;
+  void write_debug_abbrev(Assembler &assembler) const;
+  void write_debug_line(Assembler &assembler) const;
+  void write_debug_info(Assembler &assembler, u64 low_pc, u64 high_pc) const;
+  void copy_to_section(const u8 *data,
+                       size_t size,
+                       Assembler &assembler,
+                       SectionKind kind) const;
+};
+
+} // namespace tpde

--- a/tpde/include/tpde/arm64/CompilerA64.hpp
+++ b/tpde/include/tpde/arm64/CompilerA64.hpp
@@ -294,6 +294,7 @@ struct PlatformConfig : CompilerConfigDefault {
   static constexpr bool FRAME_INDEXING_NEGATIVE = false;
   static constexpr u32 PLATFORM_POINTER_SIZE = 8;
   static constexpr u32 NUM_BANKS = 2;
+  static constexpr u8 MIN_INST_WIDTH = 4;
 };
 
 /// Compiler mixin for targeting AArch64.
@@ -1063,14 +1064,17 @@ void CompilerA64<Adaptor, Derived, BaseTy, Config>::finish_func(u32 func_idx) {
   }
 
   // TODO(ts): honor cur_needs_unwind_info
+  const u32 prologue_shrink_size = func_prologue_alloc - prologue_size;
   this->text_writer.remove_prologue_bytes(func_start_off + prologue_size,
-                                          func_prologue_alloc - prologue_size);
+                                          prologue_shrink_size);
   auto func_size = this->text_writer.offset() - func_start_off;
   auto func_sym = this->func_syms[func_idx];
   auto func_sec = this->text_writer.get_sec_ref();
   this->assembler.sym_def(func_sym, func_sec, func_start_off, func_size);
   this->text_writer.eh_end_fde();
   this->text_writer.except_encode_func();
+
+  this->func_sym_id_to_skew[func_sym.id()] = prologue_shrink_size;
 }
 
 template <IRAdaptor Adaptor,

--- a/tpde/include/tpde/x64/CompilerX64.hpp
+++ b/tpde/include/tpde/x64/CompilerX64.hpp
@@ -828,14 +828,17 @@ void CompilerX64<Adaptor, Derived, BaseTy, Config>::finish_func(u32 func_idx) {
   // Do sym_def at the very end; we shorten the function here again, so only at
   // this point we know the actual size of the function.
   // TODO(ts): honor cur_needs_unwind_info
+  const u32 prologue_shrink_size = func_prologue_alloc - prologue_size;
   this->text_writer.remove_prologue_bytes(func_start_off + prologue_size,
-                                          func_prologue_alloc - prologue_size);
+                                          prologue_shrink_size);
   auto func_size = this->text_writer.offset() - func_start_off;
   auto func_sym = this->func_syms[func_idx];
   auto func_sec = this->text_writer.get_sec_ref();
   this->assembler.sym_def(func_sym, func_sec, func_start_off, func_size);
   this->text_writer.eh_end_fde();
   this->text_writer.except_encode_func();
+
+  this->func_sym_id_to_skew[func_sym.id()] = prologue_shrink_size;
 }
 
 template <IRAdaptor Adaptor,

--- a/tpde/src/AssemblerElf.cpp
+++ b/tpde/src/AssemblerElf.cpp
@@ -39,6 +39,9 @@ constexpr static std::span<const char> SHSTRTAB = {
     ".rela.gcc_except_table\0"
     ".rela.init_array\0"
     ".rela.fini_array\0"
+    ".debug_info\0"
+    ".debug_line\0"
+    ".debug_abbrev\0"
     ".group\0"
     ".symtab_shndx\0"};
 
@@ -522,6 +525,21 @@ static consteval auto get_elf_section_flags() {
                    .name = sec_off(".tbss"),
                    .has_relocs = false,
                    .is_bss = true};
+  section_flags[u8(SectionKind::DebugInfo)] =
+      SectionFlags{.type = SHT_PROGBITS,
+                   .flags = SHF_ALLOC,
+                   .name = sec_off(".debug_info"),
+                   .has_relocs = false};
+  section_flags[u8(SectionKind::DebugLine)] =
+      SectionFlags{.type = SHT_PROGBITS,
+                   .flags = SHF_ALLOC,
+                   .name = sec_off(".debug_line"),
+                   .has_relocs = false};
+  section_flags[u8(SectionKind::DebugAbbrev)] =
+      SectionFlags{.type = SHT_PROGBITS,
+                   .flags = SHF_ALLOC,
+                   .name = sec_off(".debug_abbrev"),
+                   .has_relocs = false};
   return section_flags;
 }
 

--- a/tpde/src/DwarfLineWriter.cpp
+++ b/tpde/src/DwarfLineWriter.cpp
@@ -1,0 +1,371 @@
+// SPDX-FileCopyrightText: 2025 Contributors to TPDE <https://tpde.org>
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "tpde/DwarfLineWriter.hpp"
+
+#include "tpde/Assembler.hpp"
+#include "tpde/DWARF.hpp"
+
+#include <algorithm>
+#include <cassert>
+#include <cstring>
+
+namespace tpde {
+
+DwarfLineWriter::DwarfLineWriter(const tpde::DwarfConfig &cfg) : cfg(cfg) {}
+
+void DwarfLineWriter::push_location(u32 raw_pc_offset, DebugLocation loc) {
+  pending.emplace_back(raw_pc_offset, std::move(loc));
+}
+
+bool DwarfLineWriter::offset_equals_last_offset(u32 raw_pc_offset) {
+  return !pending.empty() && raw_pc_offset == pending.back().raw_pc_offset;
+}
+
+void DwarfLineWriter::end_function(u32 skew) {
+  if (pending.empty()) {
+    return;
+  }
+
+  // Apply skew to all pending entries except the initial entry for the function
+  // itself if a subprogram has been written.
+  auto it = subprogram_written ? pending.begin() + 1 : pending.begin();
+  for (; it != pending.end(); ++it) {
+    it->raw_pc_offset -= skew;
+  }
+
+  const auto comp = [](const PendingEntry &a, const PendingEntry &b) {
+    return a.raw_pc_offset < b.raw_pc_offset;
+  };
+  std::ranges::stable_sort(pending, comp);
+
+  // Track PC range for .debug_info.
+  low_pc = std::min(low_pc, static_cast<u64>(pending.front().raw_pc_offset));
+  high_pc = std::max(high_pc, static_cast<u64>(pending.back().raw_pc_offset));
+
+  // Emit DWARF state-machine opcodes into prog_buf.
+  util::VectorWriter w(prog_buf);
+
+  if (!sequence_started) {
+    emit_set_address(w, pending.front().raw_pc_offset);
+    state.address = pending.front().raw_pc_offset;
+    sequence_started = true;
+  }
+
+  for (const PendingEntry &e : pending) {
+    const u32 file_idx =
+        ensure_file(e.loc.file_name, ensure_dir(e.loc.directory));
+    emit_record(
+        w, e.raw_pc_offset, file_idx, e.loc.line, e.loc.column, false, false);
+  }
+
+  // Reset state for next function
+  state.prologue_end = false;
+  state.epilogue_begin = false;
+  pending.clear();
+  subprogram_written = false;
+}
+
+void DwarfLineWriter::finalize(Assembler &assembler) {
+  // If the buffer is empty, we don't need to write the DWARF sections
+  if (prog_buf.empty()) {
+    return;
+  }
+
+  // Close the single line program sequence.
+  {
+    util::VectorWriter w(prog_buf);
+    emit_end_sequence(w);
+  }
+
+  // --- .debug_line ---
+  write_debug_line(assembler);
+
+  // --- .debug_abbrev ---
+  write_debug_abbrev(assembler);
+
+  // --- .debug_info ---
+  // high_pc is exclusive (one past the last recorded offset).
+  write_debug_info(assembler, low_pc, high_pc + 1);
+}
+
+void DwarfLineWriter::set_subprogram_written() { subprogram_written = true; }
+
+// ---- file/directory table helpers -------------------------------------------
+
+u32 DwarfLineWriter::ensure_dir(const std::string_view &dir) {
+  const auto [it, inserted] =
+      dir_idx_map.try_emplace(dir, static_cast<u32>(directories.size()));
+  if (inserted) {
+    directories.push_back(dir);
+  }
+  return it->second;
+}
+
+u32 DwarfLineWriter::ensure_file(const std::string_view &name, u32 dir_idx) {
+  const auto key = std::make_pair(dir_idx, name);
+  const auto [it, inserted] =
+      file_idx_map.try_emplace(key, static_cast<u32>(files.size()));
+  if (inserted) {
+    files.emplace_back(name, dir_idx);
+  }
+  return it->second;
+}
+
+// ---- DWARF opcode emitters --------------------------------------------------
+
+void DwarfLineWriter::emit_set_address(util::VectorWriter &w, u64 addr) {
+  w.write<u8>(dwarf::DW_LNS_extended_op);
+  w.write_uleb(1 + 8);
+  w.write<u8>(dwarf::DW_LNE_set_address);
+  w.write<u64>(addr);
+}
+
+void DwarfLineWriter::emit_end_sequence(util::VectorWriter &w) {
+  w.write<u8>(dwarf::DW_LNS_extended_op);
+  w.write_uleb(1);
+  w.write<u8>(dwarf::DW_LNE_end_sequence);
+}
+
+void DwarfLineWriter::emit_advance_line(util::VectorWriter &w, i32 delta) {
+  w.write<u8>(dwarf::DW_LNS_advance_line);
+  w.write_sleb(delta);
+}
+
+void DwarfLineWriter::emit_advance_pc(util::VectorWriter &w, u64 delta) {
+  w.write<u8>(dwarf::DW_LNS_advance_pc);
+  w.write_uleb(delta);
+}
+
+void DwarfLineWriter::emit_set_file(util::VectorWriter &w, u32 file_idx) {
+  w.write<u8>(dwarf::DW_LNS_set_file);
+  w.write_uleb(file_idx);
+}
+
+void DwarfLineWriter::emit_set_column(util::VectorWriter &w, u32 col) {
+  w.write<u8>(dwarf::DW_LNS_set_column);
+  w.write_uleb(col);
+}
+
+void DwarfLineWriter::emit_set_prologue_end(util::VectorWriter &w) {
+  w.write<u8>(dwarf::DW_LNS_set_prologue_end);
+}
+
+void DwarfLineWriter::emit_set_epilogue_begin(util::VectorWriter &w) {
+  w.write<u8>(dwarf::DW_LNS_set_epilogue_begin);
+}
+
+void DwarfLineWriter::emit_copy(util::VectorWriter &w) {
+  w.write<u8>(dwarf::DW_LNS_copy);
+}
+
+void DwarfLineWriter::emit_record(util::VectorWriter &w,
+                                  u32 pc_offset,
+                                  u32 file_idx,
+                                  u32 line,
+                                  u16 col,
+                                  bool prologue_end,
+                                  bool epilogue_begin) {
+  const u64 addr_delta = pc_offset - state.address;
+  if (addr_delta != 0) {
+    emit_advance_pc(w, addr_delta / cfg.minimum_instruction_length);
+    state.address = pc_offset;
+  }
+
+  const i32 line_delta = static_cast<i32>(line) - static_cast<i32>(state.line);
+  if (line_delta != 0) {
+    emit_advance_line(w, line_delta);
+    state.line = line;
+  }
+
+  if (file_idx != state.file) {
+    emit_set_file(w, file_idx);
+    state.file = file_idx;
+  }
+
+  if (col != state.column) {
+    emit_set_column(w, col);
+    state.column = col;
+  }
+
+  if (prologue_end && !state.prologue_end) {
+    emit_set_prologue_end(w);
+    state.prologue_end = true;
+  }
+
+  if (epilogue_begin && !state.epilogue_begin) {
+    emit_set_epilogue_begin(w);
+    state.epilogue_begin = true;
+  }
+
+  emit_copy(w);
+}
+
+// ---- section writing helpers ------------------------------------------------
+
+void DwarfLineWriter::write_directory_table(util::VectorWriter &w) const {
+  // DWARF 5 format: format_count, formats, entry_count, entries.
+  w.write<u8>(1); // directory_entry_format_count
+  w.write_uleb(dwarf::DW_LNCT_path);
+  w.write_uleb(dwarf::DW_FORM_string);
+  w.write_uleb(directories.size());
+  for (const std::string_view &d : directories) {
+    write_string(w, d);
+  }
+}
+
+void DwarfLineWriter::write_file_table(util::VectorWriter &w) const {
+  // DWARF 5 format: format_count, formats, entry_count, entries.
+  w.write<u8>(2); // file_name_entry_format_count
+  w.write_uleb(dwarf::DW_LNCT_path);
+  w.write_uleb(dwarf::DW_FORM_string);
+  w.write_uleb(dwarf::DW_LNCT_directory_index);
+  w.write_uleb(dwarf::DW_FORM_udata);
+  w.write_uleb(files.size());
+
+  for (const DebugFileEntry &f : files) {
+    write_string(w, f.name);
+    w.write_uleb(f.dir_index);
+  }
+}
+
+void DwarfLineWriter::write_string(util::VectorWriter &w,
+                                   const std::string_view &s) const {
+  const auto *data = reinterpret_cast<const u8 *>(s.data());
+  w.write(std::span<const u8>(data, s.size()));
+  w.write<u8>(0); // null terminator
+}
+
+void DwarfLineWriter::write_debug_abbrev(Assembler &assembler) const {
+  util::SmallVector<u8, 256> buf;
+  util::VectorWriter w(buf);
+
+  w.write_uleb(1); // abbrev code
+  w.write_uleb(dwarf::DW_TAG_compile_unit);
+  w.write<u8>(dwarf::DW_CHILDREN_no);
+
+  w.write_uleb(dwarf::DW_AT_stmt_list);
+  w.write_uleb(dwarf::DW_FORM_sec_offset);
+
+  w.write_uleb(dwarf::DW_AT_low_pc);
+  w.write_uleb(dwarf::DW_FORM_addr);
+
+  w.write_uleb(dwarf::DW_AT_high_pc);
+  w.write_uleb(dwarf::DW_FORM_addr);
+
+  w.write_uleb(0); // end of attributes
+  w.write_uleb(0);
+  w.write<u8>(0); // end of abbrev table
+
+  w.flush();
+  copy_to_section(w.data(), w.size(), assembler, SectionKind::DebugAbbrev);
+}
+
+void DwarfLineWriter::write_debug_line(Assembler &assembler) const {
+  // Write the header into a temporary buffer, then copy header + prog_buf
+  // into the section as one contiguous block.
+  util::SmallVector<u8, 4096> hdr_buf;
+  util::VectorWriter hw(hdr_buf);
+
+  // unit_length placeholder (filled after we know total size)
+  const u32 unit_len_off = static_cast<u32>(hw.size());
+  hw.write<u32>(0);
+
+  hw.write<u16>(5); // DWARF version 5
+  hw.write<u8>(8);  // address_size (64-bit)
+  hw.write<u8>(0);  // segment_selector_size
+
+  // header_length placeholder (filled after header body is written)
+  const u32 hdr_len_off = static_cast<u32>(hw.size());
+  hw.write<u32>(0);
+  const u32 hdr_body_start = static_cast<u32>(hw.size());
+
+  hw.write<u8>(cfg.minimum_instruction_length);
+  hw.write<u8>(1); // maximum_operations_per_instruction
+  hw.write<u8>(cfg.default_is_stmt ? 1 : 0);
+  hw.write<i8>(cfg.line_base);
+  hw.write<u8>(cfg.line_range == 0 ? 14 : cfg.line_range);
+  hw.write<u8>(cfg.opcode_base);
+
+  static constexpr u8 std_opcode_lengths[] = {
+      0, // extended
+      0, // copy
+      1, // advance_pc
+      1, // advance_line
+      1, // set_file
+      1, // set_column
+      0, // negate_stmt
+      0, // set_basic_block
+      0, // const_add_pc
+      1, // fixed_advance_pc
+      0, // set_prologue_end
+      0, // set_epilogue_begin
+      1, // set_isa
+  };
+  for (u32 i = 0; i < static_cast<u32>(cfg.opcode_base) - 1u; ++i) {
+    hw.write<u8>(std_opcode_lengths[i]);
+  }
+
+  write_directory_table(hw);
+  write_file_table(hw);
+
+  // Patch header_length: bytes from hdr_body_start to end of header.
+  hw.flush();
+  const u32 hdr_len = static_cast<u32>(hw.size()) - hdr_body_start;
+  std::memcpy(hw.data() + hdr_len_off, &hdr_len, sizeof(u32));
+
+  // Patch unit_length: from after the unit_length field to end of section.
+  const u32 unit_len = static_cast<u32>(hw.size()) - unit_len_off -
+                       sizeof(u32) + static_cast<u32>(prog_buf.size());
+  std::memcpy(hw.data() + unit_len_off, &unit_len, sizeof(u32));
+
+  // Write header then line program into the section.
+  SecRef sec = assembler.create_section(SectionKind::DebugLine);
+  DataSection &ds = assembler.get_section(sec);
+  ds.data.append(hw.data(), hw.data() + hw.size());
+  ds.data.append(prog_buf.data(), prog_buf.data() + prog_buf.size());
+  assert(sec.valid());
+}
+
+void DwarfLineWriter::write_debug_info(Assembler &assembler,
+                                       u64 low_pc,
+                                       u64 high_pc) const {
+  util::SmallVector<u8, 256> buf;
+  util::VectorWriter w(buf);
+
+  const u32 unit_len_off = static_cast<u32>(w.size());
+  w.write<u32>(0); // placeholder
+
+  w.write<u16>(5);                   // DWARF version
+  w.write<u8>(dwarf::DW_UT_compile); // unit_type
+  w.write<u8>(8);                    // address_size (64-bit)
+  w.write<u32>(0);                   // debug_abbrev_offset
+
+  w.write_uleb(1); // abbrev code = 1 (DW_TAG_compile_unit)
+
+  w.write<u32>(0);       // DW_AT_stmt_list = offset 0 into .debug_line
+  w.write<u64>(low_pc);  // DW_AT_low_pc
+  w.write<u64>(high_pc); // DW_AT_high_pc
+
+  w.write<u8>(0); // end of DIEs
+
+  w.flush();
+
+  const u32 unit_len =
+      static_cast<u32>(w.size()) - unit_len_off - static_cast<u32>(sizeof(u32));
+  std::memcpy(w.data() + unit_len_off, &unit_len, sizeof(u32));
+
+  copy_to_section(w.data(), w.size(), assembler, SectionKind::DebugInfo);
+}
+
+void DwarfLineWriter::copy_to_section(const u8 *data,
+                                      size_t size,
+                                      Assembler &assembler,
+                                      SectionKind kind) const {
+  SecRef sec = assembler.create_section(kind);
+  DataSection &ds = assembler.get_section(sec);
+  ds.data.append(data, data + size);
+  assert(sec.valid());
+}
+
+} // namespace tpde


### PR DESCRIPTION
This patch adds support for a DWARF 5 debug line info writer. It is active as soon as the IR module contains a debug metadata compile unit.
We benchmarked the performance with a ~340k line LLVM IR input file and have seen ~20% increased run time when writing debug line info for this particular IR module.