### PR TITLE
[TPDE] Fix sleb encoding helper for large deltas

### DIFF
--- a/tpde/include/tpde/util/misc.hpp
+++ b/tpde/include/tpde/util/misc.hpp
@@ -105,7 +105,7 @@ constexpr unsigned sleb_write(u8 *dst, i64 value) {
   while (true) {
     u8 write = value & 0b0111'1111;
     value >>= 7;
-    if ((value == 0 && (value & 0x40) == 0) || (value == -1 && value & 0x40)) {
+    if ((value == 0 && (write & 0x40) == 0) || (value == -1 && (write & 0x40) != 0)) {
       *dst++ = write;
       return dst - base;
     }


### PR DESCRIPTION
The sleb encoding helper fails to encode the values -128 to -65 and +64 to +127 because the wrong value was checked. I guess this was not found before, because sleb is only used with exception handling up to now, but in combination with the new line info, it caused problems.