### PR TITLE
[TPDE][LLVM] Fix register exhaustion for register-heavy encoding functions

### DIFF
--- a/tpde-llvm/test/filetest/intrin_overflow_mul128_fixed_regs.ll
+++ b/tpde-llvm/test/filetest/intrin_overflow_mul128_fixed_regs.ll
@@ -1,0 +1,34 @@
+; NOTE: Do not autogenerate
+; SPDX-FileCopyrightText: 2025 Contributors to TPDE <https://tpde.org>
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; Regression test: the x64 encoding of llvm.smul.with.overflow.i128 needs up
+; to 10 GP registers at once. Combined with 5 pre-existing fixed register
+; assignments (values kept in a register across the whole function, one per
+; callee-saved GP register), only 9 GP registers used to remain available,
+; which made the register allocator abort with
+; "TPDE FATAL ERROR: ran out of registers for scratch registers" instead of
+; compiling successfully.
+; RUN: tpde-llc --target=x86_64 %s -o %t.o
+
+declare {i128, i1} @llvm.smul.with.overflow.i128(i128, i128)
+declare void @use(i64, i64, i64, i64, i64)
+
+define void @trigger_fixed_reg_pressure_smul128(i64 %x, i128 %a, i128 %b) {
+entry:
+  %v1 = add i64 %x, 1
+  %v2 = add i64 %x, 2
+  %v3 = add i64 %x, 3
+  %v4 = add i64 %x, 4
+  %v5 = add i64 %x, 5
+  ; %v1..%v5 are live across the block boundary below, so the register
+  ; allocator tries to give each of them a fixed (permanently-held) GP
+  ; register, i.e. all 5 callee-saved GP registers (rbx, r12-r15).
+  %r = call {i128, i1} @llvm.smul.with.overflow.i128(i128 %a, i128 %b)
+  br label %exit
+
+exit:
+  call void @use(i64 %v1, i64 %v2, i64 %v3, i64 %v4, i64 %v5)
+  ret void
+}

--- a/tpde/include/tpde/CompilerBase.hpp
+++ b/tpde/include/tpde/CompilerBase.hpp
@@ -1447,6 +1447,12 @@ Reg CompilerBase<Adaptor, Derived, Config>::select_reg_evict(RegBank bank) {
     }
   }
   if (candidate.invalid()) [[unlikely]] {
+    // Every allocatable register of this bank is fixed (permanent
+    // cross-block assignment or in-flight scratch register).
+    TPDE_LOG_ERR("register allocator ran out of registers in bank {}: "
+                 "{} registers allocatable, all of them fixed",
+                 bank.id(),
+                 register_file.allocatable_count(bank));
     TPDE_FATAL("ran out of registers for scratch registers");
   }
   TPDE_LOG_DBG("  selected r{}", candidate.id());
@@ -1937,6 +1943,12 @@ void CompilerBase<Adaptor, Derived, Config>::move_to_phi_nodes_impl(
         // TODO(ts): use clock here?
         reg = reg_file.find_first_nonfixed_excluding(bank, 0);
         if (reg.invalid()) {
+          // Every allocatable register of this bank is fixed (permanent
+          // cross-block assignment or in-flight scratch register).
+          TPDE_LOG_ERR("register allocator ran out of registers in bank {}: "
+                       "{} registers allocatable, all of them fixed",
+                       bank.id(),
+                       reg_file.allocatable_count(bank));
           TPDE_FATAL("ran out of registers for scratch registers");
         }
 

--- a/tpde/include/tpde/RegisterFile.hpp
+++ b/tpde/include/tpde/RegisterFile.hpp
@@ -8,6 +8,7 @@
 #include "tpde/util/misc.hpp"
 
 #include <array>
+#include <bit>
 
 namespace tpde {
 
@@ -65,6 +66,9 @@ public:
   RegBitSet allocatable = 0;
   /// Registers that are currently in use. Requires allocatable.
   RegBitSet used = 0;
+  /// Registers that cannot currently be evicted. Mirrors lock_counts[i] > 0.
+  /// Requires used.
+  RegBitSet fixed = 0;
   /// Registers that were clobbered at some point. Used to track registers that
   /// need to be saved/restored.
   RegBitSet clobbered = 0;
@@ -81,6 +85,7 @@ public:
 
   void reset() {
     used = {};
+    fixed = {};
     clobbered = {};
     clocks = {};
     lock_counts = {};
@@ -131,6 +136,7 @@ public:
     assert(is_used(reg));
     assert(lock_counts[reg.id()] == 0);
     lock_counts[reg.id()] = 1;
+    fixed |= (1ull << reg.id());
   }
 
   void unmark_fixed(const Reg reg) {
@@ -139,6 +145,7 @@ public:
     assert(is_fixed(reg));
     assert(lock_counts[reg.id()] == 1);
     lock_counts[reg.id()] = 0;
+    fixed &= ~(1ull << reg.id());
   }
 
   void inc_lock_count(const Reg reg) {
@@ -212,9 +219,26 @@ public:
     return RegBank(reg.id() / RegsPerBank);
   }
 
-  [[nodiscard]] static RegBitSet bank_regs(const RegBank bank) {
+  [[nodiscard]] static constexpr RegBitSet bank_regs(const RegBank bank) {
     assert(bank.id() <= 1);
     return ((1ull << RegsPerBank) - 1) << (bank.id() * RegsPerBank);
+  }
+
+  /// Number of allocatable registers of the given bank on this
+  /// platform/configuration; the hard upper bound on concurrently live
+  /// registers of that bank.
+  [[nodiscard]] u32 allocatable_count(const RegBank bank) const {
+    return static_cast<u32>(std::popcount(allocatable & bank_regs(bank)));
+  }
+
+  /// Number of currently-fixed registers of the given bank.
+  [[nodiscard]] u32 fixed_count(const RegBank bank) const {
+    return static_cast<u32>(std::popcount(fixed & bank_regs(bank)));
+  }
+
+  /// Number of currently-used registers of the given bank (fixed or not).
+  [[nodiscard]] u32 used_count(const RegBank bank) const {
+    return static_cast<u32>(std::popcount(used & bank_regs(bank)));
   }
 };
 

--- a/tpde/include/tpde/x64/CompilerX64.hpp
+++ b/tpde/include/tpde/x64/CompilerX64.hpp
@@ -281,10 +281,30 @@ struct CompilerX64 : BaseTy<Adaptor, Derived, Config> {
   using Base::derived;
 
 
+  // Largest number of GP registers any tpde_encodegen encoding function is
+  // known to hold live at once (encode_of_mul_i128; see
+  // test/filetest/intrin_overflow_mul128.ll). Bump if a new encoding
+  // function needs more.
+  static constexpr u32 MAX_ENCODE_FN_GP_REGS = 10;
+
   // TODO(ts): make this dependent on the number of callee-saved regs of the
   // current function or if there is a call in the function?
-  static constexpr u32 NUM_FIXED_ASSIGNMENTS[PlatformConfig::NUM_BANKS] = {5,
+  //
+  // Keep at most 4 GP registers permanently fixed, leaving enough headroom
+  // for MAX_ENCODE_FN_GP_REGS.
+  static constexpr u32 NUM_FIXED_ASSIGNMENTS[PlatformConfig::NUM_BANKS] = {4,
                                                                            6};
+
+  // Catch insufficient headroom at compile time rather than crashing at
+  // runtime with "ran out of registers for scratch registers".
+  static_assert(
+      NUM_FIXED_ASSIGNMENTS[0] + MAX_ENCODE_FN_GP_REGS <=
+          static_cast<u32>(
+              std::popcount(CCAssignerSysV::Info.allocatable_regs &
+                            RegisterFile::bank_regs(PlatformConfig::GP_BANK))),
+      "NUM_FIXED_ASSIGNMENTS[GP_BANK] leaves too few free GP registers for "
+      "register-heavy encoding functions like encode_of_mul_i128 "
+      "(see MAX_ENCODE_FN_GP_REGS)");
 
   static constexpr u32 MaxStaticAllocaSize = 0x10000000;
 


### PR DESCRIPTION
Some tpde_encodegen encoding functions (e.g. encode_of_mul_i128, the __int128 multiply-with-overflow snippet) need up to 10 GP registers live at once. With 5 GP registers permanently held by cross-block fixed assignments, only 9 of the 14 allocatable GP registers remained, so the register allocator aborted with "ran out of registers for scratch registers" instead of compiling. Reduce
NUM_FIXED_ASSIGNMENTS[GP_BANK] from 5 to 4 to leave enough headroom.

Also add a two-layer assertion mechanism to catch a regression of this class of bug earlier:
- A static_assert ties NUM_FIXED_ASSIGNMENTS[GP_BANK] to the documented worst-case concurrent register demand of a known encoding function, failing the build instead of crashing at runtime if the headroom is ever reduced again.
- The two sites that can hit "ran out of registers for scratch registers" now log the bank id and allocatable register count before aborting.

Fixes #45 